### PR TITLE
Add support for png, svg and jpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ https://stackoverflow.com/questions/31607458/how-to-add-clipboard-support-to-mat
 
 Releases
 --------
+### 2.1.0: 2020-08-27
+
+- Remove Pillow
+- Add support for png, svg, jpg, jpeg fileformat.
 
 ### 2.0.0: 2019-04-15
 


### PR DESCRIPTION
Hi,

I needed png and svg support to handle alpha and also to avoid heavy bitmaps.
I dug into the Windows API and figured out how to directly copy png, svg and jpg/jpeg that are produced by matplotlib.

This closes #3 

I hope you like it !