### PR TITLE
allow users to select dpi / format / whatever

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ https://stackoverflow.com/questions/31607458/how-to-add-clipboard-support-to-mat
 Advanced Control
 --------
 to control dpi, image-format, or other savefig key words, set their value after importing like so:
+```python
 import addcopyfighandler
 addcopyfighandler.image_file_format = "png"
 addcopyfighandler.image_dpi = 250
 addcopyfighandler.other_savefig_kwargs = {"pad_inches":0.5,"transparent":True}
-
+```
 
 Releases
 --------

--- a/README.md
+++ b/README.md
@@ -8,9 +8,21 @@ the figure to the clipboard as an image.
 Original concept code taken from:
 https://stackoverflow.com/questions/31607458/how-to-add-clipboard-support-to-matplotlib-figures
 
+Advanced Controll
+--------
+to control dpi, image-format, or other savefig key wards, set their falue after importing like so:
+import addcopyfighandler
+addcopyfighandler.image_file_format = "png"
+addcopyfighandler.image_dpi = 250
+addcopyfighandler.other_savefig_kwargs = {"pad_inches":0.5,"transparent":True}
+
 
 Releases
 --------
+### 2.1.1: 2020-08-27
+
+- add user input method for image-format and dpi control
+
 ### 2.1.0: 2020-08-27
 
 - Remove Pillow

--- a/addcopyfighandler.py
+++ b/addcopyfighandler.py
@@ -15,9 +15,12 @@ from win32gui import GetWindowText, GetForegroundWindow
 import win32clipboard
 from io import BytesIO
 
-__version__ = (2, 1, 0)
+__version__ = (2, 1, 1)
 oldfig = plt.figure
 
+image_file_format = None
+image_dpi = None
+other_savefig_kwargs = {}
 
 def copyfig(fig=None, *args, **kwargs):
     """
@@ -75,7 +78,13 @@ def newfig(*args, **kwargs):
 
     def clipboard_handler(event):
         if event.key == 'ctrl+c':
-            copyfig()
+            kwargs = {}
+            kwargs.update(other_savefig_kwargs)
+            if file_format:
+                kwargs["format"] = file_format
+            if image_dpi:
+                kwargs["dpi"] = image_dpi
+            copyfig(**kwargs)
 
     fig.canvas.mpl_connect('key_press_event', clipboard_handler)
     return fig

--- a/addcopyfighandler.py
+++ b/addcopyfighandler.py
@@ -80,8 +80,8 @@ def newfig(*args, **kwargs):
         if event.key == 'ctrl+c':
             kwargs = {}
             kwargs.update(other_savefig_kwargs)
-            if file_format:
-                kwargs["format"] = file_format
+            if image_file_format:
+                kwargs["format"] = image_file_format
             if image_dpi:
                 kwargs["dpi"] = image_dpi
             copyfig(**kwargs)


### PR DESCRIPTION
I needed this functionality, so I made it for me, and though I would PR it:
added user input method for image-format and dpi control
and added documentation of use usage in readme:

to control dpi, image-format, or other savefig key words, set their value after importing like so:
```python
import addcopyfighandler
addcopyfighandler.image_file_format = "png"
addcopyfighandler.image_dpi = 250
addcopyfighandler.other_savefig_kwargs = {"pad_inches":0.5,"transparent":True}
```